### PR TITLE
[add] style.css

### DIFF
--- a/ipynb/Cheryl.ipynb
+++ b/ipynb/Cheryl.ipynb
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -101,7 +101,7 @@
        "'5월'"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -121,7 +121,7 @@
        "'15일'"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -173,7 +173,7 @@
        "['5월 15일', '5월 16일', '5월 19일']"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -200,7 +200,7 @@
        "['5월 15일', '8월 15일']"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -227,7 +227,7 @@
        "False"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -250,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -329,7 +329,7 @@
        "False"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -347,7 +347,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -356,7 +356,7 @@
        "['7월 14일', '7월 16일', '8월 14일', '8월 15일', '8월 17일']"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -379,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -408,7 +408,7 @@
        "['7월 16일', '8월 15일', '8월 17일']"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -431,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -461,7 +461,7 @@
        "['7월 16일']"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -479,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -488,7 +488,7 @@
        "True"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -496,9 +496,121 @@
    "source": [
     "know(cheryls_birthday())"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>@import url(//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSans-kr.css);\n",
+       "@import url(https://cdn.jsdelivr.net/gh/Joungkyun/font-d2coding@1.31.0/d2coding-ligature.min.css);\n",
+       "\n",
+       "/* All Jupyter NB cell */\n",
+       "\n",
+       "#notebook-container {\n",
+       "  font-family: 'Spoqa Han Sans', sans-serif;\n",
+       "  font-size: 17px;\n",
+       "  line-height: 1.65;\n",
+       "}\n",
+       "\n",
+       ".cell {\n",
+       "  margin-top: 1.5em;\n",
+       "  margin-bottom: 1.5em;\n",
+       "}\n",
+       "\n",
+       "/* Markdown Paragraphs are wrapped in `div.text_cell_render` */\n",
+       "\n",
+       ".text_cell_render {\n",
+       "  padding: 0;\n",
+       "}\n",
+       "\n",
+       ".text_cell_render p {\n",
+       "  margin-bottom: 1.3em;\n",
+       "}\n",
+       "\n",
+       ".text_cell_render h1,\n",
+       ".text_cell_render h2,\n",
+       ".text_cell_render h3,\n",
+       ".text_cell_render h4 {\n",
+       "  margin: 1.414em 0 0.5em;\n",
+       "  font-weight: inherit;\n",
+       "  line-height: 1.2;\n",
+       "}\n",
+       "\n",
+       ".text_cell_render h1 {\n",
+       "  margin-top: 0;\n",
+       "  font-size: 3.157em;\n",
+       "  text-align: center;\n",
+       "}\n",
+       "\n",
+       ".text_cell_render h2 {\n",
+       "  font-size: 2.369em;\n",
+       "  border-bottom: .1em solid #0074D9;\n",
+       "}\n",
+       "\n",
+       ".text_cell_render h3 {\n",
+       "  font-size: 1.777em;\n",
+       "}\n",
+       "\n",
+       ".text_cell_render h4 {\n",
+       "  font-size: 1.333em;\n",
+       "}\n",
+       "\n",
+       "/* Code Area */\n",
+       "\n",
+       ".input_area>div,\n",
+       ".highlight {\n",
+       "  font-family: \"D2 coding Ligature\", monospace;\n",
+       "  font-size: 1.1em;\n",
+       "  line-height: 1.5;\n",
+       "}\n",
+       "\n",
+       "code,\n",
+       "pre {\n",
+       "  font-family: \"D2 coding Ligature\", monospace;\n",
+       "}\n",
+       "\n",
+       "/* Inline code inside markdown */\n",
+       "\n",
+       ".rendered_html p code {\n",
+       "  color: #Cd3700;\n",
+       "}\n",
+       "</style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.core.display import HTML\n",
+    "\n",
+    "def css_styling():\n",
+    "    styles = open(\"../styles/style.css\", \"r\").read()\n",
+    "    return HTML(\"<style>{}</style>\".format(styles))\n",
+    "\n",
+    "css_styling()"
+   ]
   }
  ],
  "metadata": {
+  "_draft": {
+   "nbviewer_url": "https://gist.github.com/8cc1d0da60f8c4fc57025373ad7a506a"
+  },
+  "gist": {
+   "data": {
+    "description": "Cheryl.ipynb",
+    "public": true
+   },
+   "id": "8cc1d0da60f8c4fc57025373ad7a506a"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -514,7 +626,60 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.1"
+  },
+  "toc": {
+   "colors": {
+    "hover_highlight": "#DAA520",
+    "navigate_num": "#000000",
+    "navigate_text": "#333333",
+    "running_highlight": "#FF0000",
+    "selected_highlight": "#FFD700",
+    "sidebar_border": "#EEEEEE",
+    "wrapper_background": "#FFFFFF"
+   },
+   "moveMenuLeft": true,
+   "nav_menu": {
+    "height": "216px",
+    "width": "252px"
+   },
+   "navigate_menu": true,
+   "number_sections": true,
+   "sideBar": true,
+   "threshold": 4,
+   "toc_cell": false,
+   "toc_section_display": "block",
+   "toc_window_display": false,
+   "widenNotebook": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,

--- a/styles/style.css
+++ b/styles/style.css
@@ -1,0 +1,73 @@
+@import url(//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSans-kr.css);
+@import url(https://cdn.jsdelivr.net/gh/Joungkyun/font-d2coding@1.31.0/d2coding-ligature.min.css);
+
+/* All Jupyter NB cell */
+
+#notebook-container {
+  font-family: 'Spoqa Han Sans', sans-serif;
+  font-size: 17px;
+  line-height: 1.65;
+}
+
+.cell {
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}
+
+/* Markdown Paragraphs are wrapped in `div.text_cell_render` */
+
+.text_cell_render {
+  padding: 0;
+}
+
+.text_cell_render p {
+  margin-bottom: 1.3em;
+}
+
+.text_cell_render h1,
+.text_cell_render h2,
+.text_cell_render h3,
+.text_cell_render h4 {
+  margin: 1.414em 0 0.5em;
+  font-weight: inherit;
+  line-height: 1.2;
+}
+
+.text_cell_render h1 {
+  margin-top: 0;
+  font-size: 3.157em;
+  text-align: center;
+}
+
+.text_cell_render h2 {
+  font-size: 2.369em;
+  border-bottom: .1em solid #0074D9;
+}
+
+.text_cell_render h3 {
+  font-size: 1.777em;
+}
+
+.text_cell_render h4 {
+  font-size: 1.333em;
+}
+
+/* Code Area */
+
+.input_area>div,
+.highlight {
+  font-family: "D2 coding Ligature", monospace;
+  font-size: 1.1em;
+  line-height: 1.5;
+}
+
+code,
+pre {
+  font-family: "D2 coding Ligature", monospace;
+}
+
+/* Inline code inside markdown */
+
+.rendered_html p code {
+  color: #Cd3700;
+}


### PR DESCRIPTION
## Preview
<details>
<summary><strong>Image preview</strong></summary>
<img src="https://user-images.githubusercontent.com/2981167/36359589-9fcd4b86-14d1-11e8-929d-77f76149d6f1.png" alt="Preview Image" >
</details>

<details>
<summary><strong>NB Viewer</strong></summary>
<a href="https://nbviewer.jupyter.org/github/cynthia/pytudes/blob/CSS/ipynb/Cheryl.ipynb?flush_cache=true">Link</a>
</details>

## Summary

1. Add `style.css` for nbviewer
    - Improve typography by following Type Scale
    - Change the coding font to D2Coding because the ligature is awesome :laughing: 
        - Spoqa Han Sans for markdown

In order to load `style.css`, copy and paste into the last cell of an ipynb and **run** it

```python
from IPython.core.display import HTML

def css_styling():
    styles = open("../styles/style.css", "r").read()
    return HTML("<style>{}</style>".format(styles))

css_styling()
```

## Why?

- for future reference 

## Notes

- it does not work on GitHub
- it only works in a local environment & nbviewer

